### PR TITLE
Fixes #20: error: 'CONST' has not been declared

### DIFF
--- a/src/WIFIManager.cpp
+++ b/src/WIFIManager.cpp
@@ -21,6 +21,10 @@
 
 #include "../html/home.htm.h"
 
+#ifndef CONST
+#define CONST const
+#endif
+
 #define DNS_PORT    53
 #define HTTP_PORT   80
 


### PR DESCRIPTION
When I build under VScode + Platformio, I have a error concerning the macro CONST that is not defined :

```
> Executing task: C:\Users\pasca\.platformio\penv\Scripts\platformio.exe run --environment nodemcuv2 <

Processing nodemcuv2 (platform: espressif8266; board: nodemcuv2; framework: arduino)
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
CONFIGURATION: https://docs.platformio.org/page/boards/espressif8266/nodemcuv2.html
PLATFORM: Espressif 8266 (3.2.0) > NodeMCU 1.0 (ESP-12E Module)
HARDWARE: ESP8266 80MHz, 80KB RAM, 4MB Flash
PACKAGES:
 - framework-arduinoespressif8266 3.30002.0 (3.0.2)
 - tool-esptool 1.413.0 (4.13)
 - tool-esptoolpy 1.30000.201119 (3.0.0)
 - toolchain-xtensa 2.100300.210717 (10.3.0)
LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 35 compatible libraries
Scanning dependencies...
Dependency Graph
|-- <ESP8266WiFi> 1.0
|-- <EEPROM> 1.0
|-- <ESP8266httpUpdate> 1.3
|   |-- <ESP8266HTTPClient> 1.2
|   |   |-- <ESP8266WiFi> 1.0
|   |-- <ESP8266WiFi> 1.0
|-- <ArduinoOTA> 1.0
|   |-- <ESP8266WiFi> 1.0
|   |-- <ESP8266mDNS> 1.2
|   |   |-- <ESP8266WiFi> 1.0
|-- <DNSServer> 1.1.1
|   |-- <ESP8266WiFi> 1.0
|-- <ESP8266WebServer> 1.0
|   |-- <ESP8266WiFi> 1.0
Building in release mode
Warning! '-Wl,-T' option for specifying linker scripts is deprecated. Please use 'board_build.ldscript' option in your 'platformio.ini' file.
Compiling .pio\build\nodemcuv2\src\WIFIManager.cpp.o
src\WIFIManager.cpp:49:49: error: 'CONST' has not been declared
   49 | void check_dns_found_callback(const char *name, CONST ip_addr_t *ipaddr, void *callback_arg);
      |                                                 ^~~~~
src\WIFIManager.cpp:49:65: error: expected ',' or '...' before '*' token
   49 | void check_dns_found_callback(const char *name, CONST ip_addr_t *ipaddr, void *callback_arg);
      |                                                                 ^
src\WIFIManager.cpp: In member function 'void WIFIManager::checks()':
src\WIFIManager.cpp:315:79: error: invalid conversion from 'void (*)(const char*, int)' to 'dns_found_callback' {aka 'void (*)(const char*, const ip4_addr*, void*)'} [-fpermissive]
  315 |           err_t err = dns_gethostbyname(_settings.getBrokerHost(), &_checkip, &check_dns_found_callback, &_checkIPAddress);
      |                                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                               |
      |                                                                               void (*)(const char*, int)
In file included from src\WIFIManager.cpp:17:
C:\Users\pasca\.platformio\packages\framework-arduinoespressif8266\tools\sdk\lwip2\include/lwip/dns.h:110:55: note:   initializing argument 3 of 'err_t dns_gethostbyname(const char*, ip_addr_t*, dns_found_callback, void*)'
  110 |                                    dns_found_callback found, void *callback_arg);
      |                                    ~~~~~~~~~~~~~~~~~~~^~~~~
src\WIFIManager.cpp: At global scope:
src\WIFIManager.cpp:471:49: error: 'CONST' has not been declared
  471 | void check_dns_found_callback(const char *name, CONST ip_addr_t *ipaddr, void *callback_arg)
      |                                                 ^~~~~
src\WIFIManager.cpp:471:65: error: expected ',' or '...' before '*' token
  471 | void check_dns_found_callback(const char *name, CONST ip_addr_t *ipaddr, void *callback_arg)
      |                                                                 ^
src\WIFIManager.cpp: In function 'void check_dns_found_callback(const char*, int)':
src\WIFIManager.cpp:473:7: error: 'ipaddr' was not declared in this scope; did you mean 'ip_addr'?
  473 |   if (ipaddr) {
      |       ^~~~~~
      |       ip_addr
src\WIFIManager.cpp:474:36: error: 'callback_arg' was not declared in this scope
  474 |     (*reinterpret_cast<IPAddress*>(callback_arg)) = IPAddress(ipaddr);
      |                                    ^~~~~~~~~~~~
src\WIFIManager.cpp:476:36: error: 'callback_arg' was not declared in this scope
  476 |     (*reinterpret_cast<IPAddress*>(callback_arg)) = IPADDR_BROADCAST;
      |                                    ^~~~~~~~~~~~
*** [.pio\build\nodemcuv2\src\WIFIManager.cpp.o] Error 1
====================================================================== [FAILED] Took 5.51 seconds ==========================
```